### PR TITLE
Remove quiz keyboard shortcuts

### DIFF
--- a/crates/flasher-e2e/tests/03_quiz.rs
+++ b/crates/flasher-e2e/tests/03_quiz.rs
@@ -1,6 +1,6 @@
 //! Quiz vertical-slice e2e tests: the full review round, SRS
-//! rescheduling, the empty-quiz done state, card creation (including
-//! validation), and keyboard shortcuts — all driven through the browser
+//! rescheduling, the empty-quiz done state, and card creation (including
+//! validation) — all driven through the browser
 //! the way a user would, with the database only used for seeding and
 //! white-box verification.
 
@@ -350,44 +350,5 @@ async fn add_card_creates_disabled_new_card() -> Result<()> {
             "empty-prompt submit must not create a card; store holds {total}"
         )));
     }
-    Ok(())
-}
-
-/// Keyboard flow: Space reveals the solution, `2` rates OK, and the done
-/// state appears.
-#[tokio::test]
-#[ignore = "browser"]
-async fn quiz_keyboard_shortcuts_drive_round() -> Result<()> {
-    let h = TestHarness::start().await?;
-    let (store, user_id) = seed_store(&h).await?;
-    let now = now_ms();
-    seed_card(
-        &store,
-        user_id,
-        "card-keys",
-        "Key prompt",
-        "Key solution",
-        CardState::New,
-        now - 60_000,
-        now - 1_000,
-        false,
-    )
-    .await?;
-
-    h.goto("/").await?;
-    h.wait_for_text("#quiz-prompt", "Key prompt", TIMEOUT)
-        .await?;
-
-    // Focus the page body (not a form field) so the global shortcuts are
-    // active, then press the keys a user would press.
-    let body = h.page.find_element("body").await.map_err(Error::Cdp)?;
-    body.click().await.map_err(Error::Cdp)?;
-    body.press_key(" ").await.map_err(Error::Cdp)?;
-    h.wait_for_text("#quiz-solution", "Key solution", TIMEOUT)
-        .await?;
-    h.screenshot("03_quiz/keyboard-solution").await?;
-    body.press_key("2").await.map_err(Error::Cdp)?;
-    h.wait_for_text("#quiz-done", "All done", TIMEOUT).await?;
-    h.screenshot("03_quiz/keyboard-done").await?;
     Ok(())
 }

--- a/docs/plan.html
+++ b/docs/plan.html
@@ -410,7 +410,7 @@ browser e2e (clicking) together — never a backend without its user-facing test
   <ul class="checks">
     <li class="done"><code>flasher-core</code>: SRS ported exactly from C# (ok ×1.8 / failed ×0.5555 of elapsed interval, new-card wait 30 min on create); 24/24 mutants caught; tunables configurable via env</li>
     <li class="done">Cards endpoints (next, create-as-disabled, set-ok, set-failed); single-user mode (<code>FLASHER_USER</code> optional, single-db-user auto-resolution) as the Phase-5 auth seam</li>
-    <li class="done">Quiz UI: prompt → reveal → rate, keyboard shortcuts (Space / 1 / 2), add-card form, done/error states; 4 SSR tests</li>
+    <li class="done">Quiz UI: prompt → reveal → rate, add-card form, done/error states; 4 SSR tests</li>
     <li class="done">5 browser e2e tests clicking through the full round incl. SRS white-box checks; wired into <code>just gate</code>; staleness guards (server always rebuilt, dist freshness-checked)</li>
   </ul>
 </div>
@@ -507,7 +507,7 @@ browser e2e (clicking) together — never a backend without its user-facing test
 visual design ideas. It's Next.js — the stack is explicitly not adopted, only the UX/structure.</div>
 <ul>
   <li><b>Design language:</b> clean, focused, dark-theme-first flashcard UI; system fonts, CSS custom properties, no framework. The card content is the hero — chrome recedes.</li>
-  <li><b>Quiz screen:</b> large readable prompt, keyboard-first (Space = reveal, 1/2 or arrows = failed/ok), visible next-due feedback after rating.</li>
+  <li><b>Quiz screen:</b> large readable prompt, tap-first (quizzing happens on the phone — no keyboard shortcuts), visible next-due feedback after rating.</li>
   <li><b>Groom screen:</b> fast search-as-you-type, clear state badges (new/ok/failed/disabled), undo-ish safety on destructive actions (confirm modal, as today).</li>
   <li><b>Editor:</b> side-by-side Markdown preview (today it's render-on-save only), autosave indicator, KaTeX in preview.</li>
   <li><b>Auth screens:</b> passkey-native flow — one button, browser prompt, done. Passkey management table with names + last-used.</li>

--- a/frontends/leptos/public/app.css
+++ b/frontends/leptos/public/app.css
@@ -82,7 +82,6 @@ body {
 /* Muted metadata text (status lines, dates, hints). */
 .quiz-status,
 .quiz-hint,
-.quiz-keys,
 .groom-status,
 .groom-due,
 .auth-hint,
@@ -381,24 +380,6 @@ textarea:focus-visible {
   flex: 1;
   padding: 0.75rem 1rem;
   font-size: 1.05rem;
-}
-
-.quiz-keys {
-  display: flex;
-  justify-content: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  margin: 0.75rem 0 0;
-}
-
-.quiz-keys kbd {
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-bottom-width: 2px;
-  border-radius: 4px;
-  padding: 0.05rem 0.4rem;
 }
 
 .quiz-status {

--- a/frontends/leptos/src/quiz.rs
+++ b/frontends/leptos/src/quiz.rs
@@ -11,10 +11,6 @@
 //! un-revealing), rating swaps it back to `/quiz`. A fresh load of
 //! `/quiz/solution` fetches the next due card and shows it ALREADY
 //! revealed; a fresh load of `/quiz` starts at the prompt as before.
-//!
-//! Keyboard shortcuts: Space/Enter shows the solution, `1` rates failed,
-//! `2` rates ok. The handler ignores keys while an input or textarea has
-//! focus so typing in the Add card form is never hijacked.
 
 use flasher_types::CardResponse;
 use leptos::prelude::*;
@@ -120,27 +116,6 @@ pub fn Quiz() -> impl IntoView {
     #[cfg(feature = "csr")]
     Effect::new(move |_| fetch_next.run(()));
 
-    // Global keyboard shortcuts (client-side only; `window()` does not
-    // exist under ssr).
-    #[cfg(feature = "csr")]
-    {
-        let handle = window_event_listener(leptos::ev::keydown, move |ev| {
-            if typing_in_form_field() {
-                return;
-            }
-            match (state.get_untracked(), ev.key().as_str()) {
-                (QuizState::Prompt(_), " " | "Enter") => {
-                    ev.prevent_default();
-                    show_solution.run(());
-                }
-                (QuizState::Solution(card), "1") => rate.run((card.id, false)),
-                (QuizState::Solution(card), "2") => rate.run((card.id, true)),
-                _ => {}
-            }
-        });
-        on_cleanup(move || handle.remove());
-    }
-
     view! {
         <section class="quiz">
             {move || match state.get() {
@@ -161,9 +136,6 @@ pub fn Quiz() -> impl IntoView {
                                 "Show solution"
                             </button>
                         </div>
-                        <p class="quiz-keys">
-                            <kbd>"Space"</kbd> " show solution"
-                        </p>
                     </div>
                 }
                     .into_any(),
@@ -192,9 +164,6 @@ pub fn Quiz() -> impl IntoView {
                                 "OK"
                             </button>
                         </div>
-                        <p class="quiz-keys">
-                            <kbd>"1"</kbd> " failed · " <kbd>"2"</kbd> " ok"
-                        </p>
                     </div>
                 }
                     .into_any(),
@@ -225,14 +194,4 @@ pub fn Quiz() -> impl IntoView {
             }}
         </section>
     }
-}
-
-/// Whether the keyboard focus is currently inside a form field — in that
-/// case global quiz shortcuts must not fire.
-#[cfg(feature = "csr")]
-fn typing_in_form_field() -> bool {
-    document().active_element().is_some_and(|el| {
-        let tag = el.tag_name();
-        tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT"
-    })
 }


### PR DESCRIPTION
Quizzing happens almost always on the phone, so the Space/Enter/1/2 key handlers were dead weight and the `<kbd>` hint lines under the quiz buttons were visual noise.

- `frontends/leptos/src/quiz.rs`: removed the global keydown listener, the form-field focus guard, both hint lines, and the module-doc paragraph.
- `frontends/leptos/public/app.css`: removed the `.quiz-keys` rules.
- `crates/flasher-e2e/tests/03_quiz.rs`: removed the keyboard-flow browser test covering the deleted feature.
- `docs/plan.html`: quiz documented as tap-first.

Verified: `just gate` green (web-gate + rust-gate + browser e2e); quiz screenshots regenerated and read — prompt and solution views show buttons only.